### PR TITLE
Download metadata urls

### DIFF
--- a/app/assets.qrc
+++ b/app/assets.qrc
@@ -12,7 +12,5 @@
 
     <qresource>
         <file alias="focusRect">assets/focusrect.png</file>
-        <file alias="sections_urls.txt">assets/sections_urls.txt</file>
-        <file alias="images_urls.txt">assets/images_urls.txt</file>
     </qresource>
 </RCC>

--- a/app/assets/UPDATING.md
+++ b/app/assets/UPDATING.md
@@ -1,9 +1,5 @@
 # How to update assets
 
-## Update urls
-
-Update URLs in "sections_urls.txt" and "images_urls.txt". Make sure to delete any removed urls.
-
 ## Update logos
 
 Update "i/logo" folder to match the same folder from getalt.

--- a/app/assets/images_urls.txt
+++ b/app/assets/images_urls.txt
@@ -1,6 +1,0 @@
-http://getalt.org/_data/images/p9-education.yml
-http://getalt.org/_data/images/p9-server-v.yml
-http://getalt.org/_data/images/p9-server.yml
-http://getalt.org/_data/images/p9-simply.yml
-http://getalt.org/_data/images/p9-workstation.yml
-http://getalt.org/_data/images/p9-kworkstation.yml

--- a/app/assets/sections_urls.txt
+++ b/app/assets/sections_urls.txt
@@ -1,3 +1,0 @@
-http://getalt.org/_data/sections/1-client.yml
-http://getalt.org/_data/sections/2-server.yml
-http://getalt.org/_data/sections/3-eduhome.yml

--- a/app/network.h
+++ b/app/network.h
@@ -23,12 +23,31 @@
 #ifndef NETWORK_H
 #define NETWORK_H
 
-#include <QString>
+#include <QObject>
+#include <QHash>
 
 class QNetworkAccessManager;
 class QNetworkReply;
 
 extern QNetworkAccessManager *network_access_manager;
+
+class NetworkReplyGroup final : public QObject {
+    Q_OBJECT
+
+public:
+    NetworkReplyGroup(const QList<QString> &url_list, QObject *parent);
+    ~NetworkReplyGroup();
+
+    QHash<QString, QNetworkReply *> get_reply_list() const;
+
+signals:
+    void finished();
+
+private:
+    QHash<QString, QNetworkReply *> reply_list;
+
+    void on_reply_finished();
+};
 
 QNetworkReply *makeNetworkRequest(const QString &url, const int time_out_millis = 0);
 

--- a/app/releasemanager.h
+++ b/app/releasemanager.h
@@ -71,9 +71,17 @@ private:
     int m_selectedIndex;
     bool m_downloadingMetadata;
     NetworkReplyGroup *metadata_reply_group;
+    NetworkReplyGroup *metadata_urls_reply_group;
+    NetworkReplyGroup *metadata_urls_backup_reply_group;
+    QList<QString> section_urls;
+    QList<QString> image_urls;
 
     void loadVariants(const QString &variantsFile);
     void setDownloadingMetadata(const bool value);
+    void downloadMetadataUrls();
+    void onMetadataUrlsDownloaded();
+    void downloadMetadataUrlsBackup();
+    void onMetadataUrlsBackupDownloaded();
     void downloadMetadata();
     void loadReleases(const QList<QString> &sectionsFiles);
     void addReleaseToModel(const int index, Release *release);

--- a/app/releasemanager.h
+++ b/app/releasemanager.h
@@ -33,6 +33,7 @@
 class Release;
 class ReleaseModel;
 class ReleaseFilterModel;
+class NetworkReplyGroup;
 
 class ReleaseManager : public QObject {
     Q_OBJECT
@@ -69,12 +70,14 @@ private:
     ReleaseFilterModel *filterModel;
     int m_selectedIndex;
     bool m_downloadingMetadata;
+    NetworkReplyGroup *metadata_reply_group;
 
     void loadVariants(const QString &variantsFile);
     void setDownloadingMetadata(const bool value);
     void downloadMetadata();
     void loadReleases(const QList<QString> &sectionsFiles);
     void addReleaseToModel(const int index, Release *release);
+    void onMetadataDownloaded();
 };
 
 #endif // RELEASEMANAGER_H


### PR DESCRIPTION
Instead of using a list of metadata urls that is built-in into the app, download it. Easier to update it that way. This also solves the absence of p10 images since an updated metadata list has already been uploaded. Because metadata lists aren't hosted on get.alt, add a backup host as a temporary band-aid.

While working on this, NetworkReplyGroup was created for reusing code that processes multiple downloads at the same time.

closes #25 