### PR TITLE
Fix deprecation warnings with Qt 5.15

### DIFF
--- a/app/dialogs/RestoreDialog.qml
+++ b/app/dialogs/RestoreDialog.qml
@@ -37,7 +37,7 @@ Dialog {
 
     Connections {
         target: drives
-        onLastRestoreableChanged: {
+        function onLastRestoreableChanged() {
             if (drives.lastRestoreable == null) {
                 root.close()
             }

--- a/app/file_type.cpp
+++ b/app/file_type.cpp
@@ -53,7 +53,7 @@ FileType file_type_from_filename(const QString &filename) {
     for (const FileType &type : file_type_all) {
         const QStringList strings = file_type_strings(type);
 
-        for (const QString string : strings) {
+        for (const QString &string : strings) {
             // NOTE: need to select the longest string for cases like ".tar" and "recovery.tar"
             const bool string_matches = filename.endsWith(string, Qt::CaseInsensitive);
             const bool this_string_is_longer = (string.length() > matching_string.length());

--- a/app/linuxdrivemanager.cpp
+++ b/app/linuxdrivemanager.cpp
@@ -117,7 +117,10 @@ void LinuxDriveProvider::init(QDBusPendingCallWatcher *watcher) {
     qDebug() << this->metaObject()->className() << "Got a reply to GetManagedObjects, parsing";
 
     QDBusPendingReply<DBusIntrospection> reply = *watcher;
-    QSet<QDBusObjectPath> oldPaths = m_drives.keys().toSet();
+    //QSet<QDBusObjectPath> oldPaths = m_drives.keys().toSet();
+    QSet<QDBusObjectPath> oldPaths = m_drives.keys().isEmpty() ?
+                QSet<QDBusObjectPath>() :
+                QSet<QDBusObjectPath>(m_drives.keys().begin(), m_drives.keys().end());
     QSet<QDBusObjectPath> newPaths;
 
     if (reply.isError()) {
@@ -174,8 +177,14 @@ void LinuxDriveProvider::onPropertiesChanged(const QString &interface_name, cons
     const QSet<QString> watchedProperties = {"MediaAvailable", "Size"};
 
     // not ideal but it works alright without a huge lot of code
-    if (!changed_properties.keys().toSet().intersect(watchedProperties).isEmpty() ||
-        !invalidated_properties.toSet().intersect(watchedProperties).isEmpty()) {
+    QSet<QString> cProp = changed_properties.keys().isEmpty() ?
+                QSet<QString>() :
+                QSet<QString>(changed_properties.keys().begin(), changed_properties.keys().end());
+    QSet<QString> iProp = invalidated_properties.isEmpty() ?
+                QSet<QString>() :
+                QSet<QString>(invalidated_properties.begin(), invalidated_properties.end());
+    if (!cProp.intersect(watchedProperties).isEmpty() ||
+        !iProp.intersect(watchedProperties).isEmpty()) {
         QDBusPendingCall pcall = m_objManager->asyncCall("GetManagedObjects");
         QDBusPendingCallWatcher *w = new QDBusPendingCallWatcher(pcall, this);
 

--- a/app/main.qml
+++ b/app/main.qml
@@ -81,7 +81,7 @@ ApplicationWindow {
 
         Connections {
             target: drives
-            onLastRestoreableChanged: {
+            function onLastRestoreableChanged() {
                 if (drives.lastRestoreable != null && !dlDialog.visible) {
                     deviceNotification.open = true
                 }
@@ -133,7 +133,7 @@ ApplicationWindow {
                 }
                 Connections {
                     target: contentLoader.item
-                    onStepForward: {
+                    function onStepForward(index) {
                         contentList.currentIndex++
                         canGoBack = true
                         releases.selectedIndex = index

--- a/app/release.cpp
+++ b/app/release.cpp
@@ -145,7 +145,7 @@ void Release::setSelectedVariantIndex(const int index) {
 }
 
 QQmlListProperty<Variant> Release::variants() {
-    return QQmlListProperty<Variant>(this, m_variants);
+    return QQmlListProperty<Variant>(this, &m_variants);
 }
 
 QList<Variant *> Release::variantList() const {

--- a/app/releasemanager.cpp
+++ b/app/releasemanager.cpp
@@ -370,7 +370,7 @@ void ReleaseManager::onMetadataDownloaded() {
                 out_set.insert(md5sum_url);
             }
 
-            const QList<QString> out = out_set.toList();
+            const QList<QString> out = out_set.values();
 
             return out;
         }();


### PR DESCRIPTION
Eng: Fix deprecation warnings with Qt 5.15

Rus: Убрал deprecation warning s при сборке с Qt 5.15.

Пригодится при переносе на Qt6.
