### PR TITLE
Fix selection of the device for writing (fix disk formatting)

### DIFF
--- a/app/dialogs/DownloadDialog.qml
+++ b/app/dialogs/DownloadDialog.qml
@@ -449,6 +449,9 @@ Dialog {
                                     releases.selected.variant.resetStatus()
                                 }
                             }
+                            onCurrentIndexChanged: {
+                                drives.setSelectedIndex(driveCombo.currentIndex)
+                            }
                             displayText: currentIndex === -1 || !currentText ? qsTr("There are no portable drives connected") : currentText
                         }
                     }

--- a/app/drivemanager.cpp
+++ b/app/drivemanager.cpp
@@ -193,14 +193,6 @@ void DriveManager::onDriveConnected(Drive *drive) {
     endInsertRows();
     emit drivesChanged();
 
-    if (m_provider->initialized()) {
-        m_selectedIndex = position;
-        emit selectedChanged();
-    } else {
-        m_selectedIndex = 0;
-        emit selectedChanged();
-    }
-
     if (drive->restoreStatus() == Drive::CONTAINS_LIVE) {
         setLastRestoreable(drive);
     }

--- a/app/drivemanager.h
+++ b/app/drivemanager.h
@@ -66,7 +66,7 @@ public:
 
     Drive *selected() const;
     int selectedIndex() const;
-    void setSelectedIndex(const int index);
+    Q_INVOKABLE void setSelectedIndex(const int index);
 
     int length() const;
 


### PR DESCRIPTION
RU: Исправление бага, который вместо выбранного пользователем устройства для записи, записывал образ на последнее смонтированное. В том числе исправлен баг, который менял выбор диска для записи в процессе записи.

[Предыдущий PR](https://github.com/altlinux/ALTMediaWriter/pull/40)